### PR TITLE
Validate incoming ocns

### DIFF
--- a/cid-minting/cid_inquiry.py
+++ b/cid-minting/cid_inquiry.py
@@ -53,6 +53,22 @@ def flat_and_dedup_sort_list(list_of_lists):
                 new_list.append(item)
     return sorted(new_list)
 
+def convert_comma_separated_str_to_int_list(ocn_str):
+    int_list=[]
+    str_list = ocn_str.split(",")
+    for a_str in str_list:
+        try:
+            ocn = int(a_str)
+        except ValueError:
+            logging.error("ValueError: {}".format(a_str))
+            continue
+        if (ocn > 0):
+            int_list.append(ocn)
+        else:
+            logging.error("ValueError: {}".format(a_str))
+
+    return int_list
+
 def usage(script_name):
     print("Parameter error.")
     print("Usage: {} env[dev|stg|prd] comma_separated_ocns".format(script_name))
@@ -110,8 +126,7 @@ def main():
     CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
 
     if (len(sys.argv) == 3):
-        ocns = sys.argv[2].split(",")
-        ocns_list = [int(i) for i in ocns]
+        ocns_list = convert_comma_separated_str_to_int_list(sys.argv[2])
 
         results = cid_inquiry(ocns_list, DB_CONNECT_STR, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
         print(json.dumps(results))
@@ -127,8 +142,7 @@ def main():
                 done_filename = os.path.join(cid_inquiry_done_dir, file + ".done")
 
                 ocns_from_filename = file[37:][:-4]
-                ocns = ocns_from_filename.split(",")
-                ocns_list = [int(i) for i in ocns]
+                ocns_list = convert_comma_separated_str_to_int_list(ocns_from_filename)
                 results = cid_inquiry(ocns_list, DB_CONNECT_STR, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
                 with open(output_filename, 'w') as output_file:
                     output_file.write(json.dumps(results))

--- a/cid-minting/tests/test_cid_inquiry.py
+++ b/cid-minting/tests/test_cid_inquiry.py
@@ -8,6 +8,7 @@ import json
 
 from cid_inquiry import cid_inquiry
 from cid_inquiry import flat_and_dedup_sort_list
+from cid_inquiry import convert_comma_separated_str_to_int_list
 from cid_inquiry import main
 
 """Test cid_inquiry() function which returns a dict with: 
@@ -606,6 +607,29 @@ def test_flat_and_dedup_sort_list():
     for k, val in input_list.items():
         assert expected[k] == flat_and_dedup_sort_list(val)
 
+def test_convert_comma_separated_str_to_int_list():
+    input_list = {
+        "1_item": "1",
+        "2_items": "1,123",
+        "empty_item_1": ",123",
+        "empty_item_2": "123,",
+        "empty_item_3": "1,,123",
+        "error_1": "-123",
+        "error_2": "ebook)ocm76968450",
+        "error_3": "ebook)ocm76968450,123",
+    }
+    expected = {
+        "1_item": [1],
+        "2_items": [1, 123],
+        "empty_item_1": [123],
+        "empty_item_2": [123],
+        "empty_item_3": [1,123],
+        "error_1": [],
+        "error_2": [],
+        "error_3": [123],
+    }
+    for k, val in input_list.items():
+        assert expected[k] == convert_comma_separated_str_to_int_list(val)
 
 # FIXTURES
 @pytest.fixture


### PR DESCRIPTION
@cscollett 
Hi Charlie,
Can you review the code change when you have a minute. It is not urgent.

The prepare and cid_inquiry pipeline was broken when prepare passed OCN="ebook)ocm76968450" to the cid inquiry. So I added error handling in the cid_inquiry.py script to limit input OCNs to positive integers. Here are the changes:

* Add a function to convert comma separated string to list of integers
* Log error when incoming ocn is not a positive integer
* Only perform CID inquiry on positive integers
* Add unit tests

Thank you

Jing