### PR TITLE
16775 select prep parallel run log

### DIFF
--- a/scripts/check_cid_difference.py
+++ b/scripts/check_cid_difference.py
@@ -21,22 +21,22 @@ with open(input_file) as fp:
         x = line.split(":")
         if (len(x) ==5):
             run_report = x[0]
-            key = x[1].strip()
-            value = x[2].strip()
+            key_item = x[1].strip()
+            value_cid = x[2].strip()
         else:
             run_report = ""
-            key = x[0].strip()
-            value = x[1].strip()
-        #print ("run_report={}: item={}: cid={}".format(run_report, key, value))
+            key_item = x[0].strip()
+            value_cid = x[1].strip()
+        #print ("run_report={}: item={}: cid={}".format(run_report, key_item, value_cid))
 
-        if key in cids.keys():
-            #print ("Key has defined: {} {}".format(key, value))
-            if cids[key] != value:
-                print ("Different CIDs:{}:item={}:new={}:old={}".format(run_report, key, cids[key], value))
-                output.write("Different CIDs:{}:{}:{}:{}\n".format(run_report, key, cids[key], value))
+        if key_item in cids.keys():
+            #print ("Key has defined: {} {}".format(key_item, value_cid))
+            if cids[key_item] != value_cid:
+                print ("Different CIDs:{}:item={}:new={}:old={}".format(run_report, key_item, cids[key_item], value_cid))
+                output.write("Different CIDs:{}:{}:{}:{}\n".format(run_report, key_item, cids[key_item], value_cid))
         else:
-            #print ("Not in, define new key/value: {} {}".format(key, value))
-            cids[key] = value
+            #print ("Not in, define new key_item/value_cid: {} {}".format(key_item, value_cid))
+            cids[key_item] = value_cid
 
 output.write("\n")
 output.write("Total processed sys IDs:{}\n".format(len(cids)))

--- a/scripts/check_cid_difference.py
+++ b/scripts/check_cid_difference.py
@@ -1,26 +1,43 @@
 import sys
+import os
 
 if (len(sys.argv) != 2):
     print("Parameter error.")
     print("Usage: {} cid_filename".format(sys.argv[0]))
     exit(1)
 
-filename = sys.argv[1]
+input_file = sys.argv[1]
+outpuf_file = os.path.splitext(input_file)[0] + "_rpt.txt"
+
+output = open(outpuf_file, "w")
+output.write("category:run_report_filename:sys_id:new_cid:old_cid\n")
 
 count = 0
 cids = {}
-with open(filename) as fp:
+with open(input_file) as fp:
    for line in fp:
         count += 1
         #print("Line {}: {}".format(count, line.strip()))
-        x = line.split(": ")
-        #print ("item={}: cid={}".format(x[0], x[1]))
-        key = x[0].strip()
-        value = x[1].strip()
+        x = line.split(":")
+        if (len(x) ==5):
+            run_report = x[0]
+            key = x[1].strip()
+            value = x[2].strip()
+        else:
+            run_report = ""
+            key = x[0].strip()
+            value = x[1].strip()
+        #print ("run_report={}: item={}: cid={}".format(run_report, key, value))
+
         if key in cids.keys():
             #print ("Key has defined: {} {}".format(key, value))
             if cids[key] != value:
-                print ("Different CIDs: item={} : {} : {}".format(key, cids[key], value))
+                print ("Different CIDs:{}:item={}:new={}:old={}".format(run_report, key, cids[key], value))
+                output.write("Different CIDs:{}:{}:{}:{}\n".format(run_report, key, cids[key], value))
         else:
             #print ("Not in, define new key/value: {} {}".format(key, value))
             cids[key] = value
+
+output.write("\n")
+output.write("Total processed sys IDs:{}\n".format(len(cids)))
+output.close()

--- a/scripts/check_cid_difference.py
+++ b/scripts/check_cid_difference.py
@@ -10,7 +10,7 @@ input_file = sys.argv[1]
 outpuf_file = os.path.splitext(input_file)[0] + "_rpt.txt"
 
 output = open(outpuf_file, "w")
-output.write("category:run_report_filename:ht_id:new_cid:old_cid\n")
+output.write("Category:Run Report Filename:HTID:CID from New Code:CID from Current Code\n")
 
 count = 0
 new_cids = []
@@ -64,7 +64,7 @@ for i in range(len(new_cids)):
                 cat = "Different CIDs"
         else:
             if not old_cid:
-                cat = "Neither current or new code find CID"
+                cat = "Neither current nor new code find CID"
             else:
                 cat = "Same CID"
         #print ("{}:{}:item={}:new={}:old={}".format(cat, run_report, item, new_cid, old_cid))

--- a/scripts/select_parallel_log.sh
+++ b/scripts/select_parallel_log.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# select parallel run logs in the past 7 days (default)
+# you can use -d <past_days> to specify past days 
+
+LOG_PATH=~/import/*/rundata/
+PAST_DAYS=7
+REPORT_DATE=`date "+%Y%m%d"`
+OUTPUT_DIR=~/import/parallel_log_analysis
+
+while getopts "d:" option
+do
+ case "${option}"
+ in
+ d) PAST_DAYS=${OPTARG} ;;
+ \?)
+    echo "Invalid option: -$OPTARG" >&2
+    exit
+    ;;
+ esac
+done
+
+echo $PAST_DAYS
+
+OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}-${PAST_DAYS}_paired_entries.txt
+
+# find log files created in the past 7 days and get the matched lines
+find $LOG_PATH -mtime -${PAST_DAYS} -type f -exec grep "create_cid_field : new" -A1 {} \+ | sed "/--$/d" | sed "s/.txt-/.txt:/g" > ${OUTPUT_FILE}
+
+PIPFILE="/apps/htmm/zephir-services/Pipfile"
+SCRIPT="/apps/htmm/zephir-services/scripts/check_cid_difference.py"
+
+if [ ! -e $SCRIPT ]; then
+  usage_error "Script $SCRIPT does not exist."
+fi
+
+cmd="pipenv run python $SCRIPT $OUTPUT_FILE"
+
+PIPENV_PIPFILE=$PIPFILE $cmd

--- a/scripts/select_parallel_log.sh
+++ b/scripts/select_parallel_log.sh
@@ -53,8 +53,7 @@ if [[ -f "$LOG_FILE" ]]; then
   grep "create_cid_field : new" -A1 $LOG_FILE > ${OUTPUT_FILE}
 elif [[ -d "$LOG_DIR" ]]; then
   if [ -z "$RPT_ID" ]; then
-    dir_name=`dirname $LOG_DIR`
-    RPT_ID=`basename $dir_name`
+    RPT_ID=`basename $LOG_DIR`
   fi
   #echo $RPT_ID
   OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}_${RPT_ID}_paired_entries.txt

--- a/scripts/select_parallel_log.sh
+++ b/scripts/select_parallel_log.sh
@@ -1,31 +1,70 @@
 #!/bin/bash
 
 # select parallel run logs in the past 7 days (default)
-# you can use -d <past_days> to specify past days 
+# you can use -p <past_days> to specify past days 
+# Options:
+# -p <past_days>: optional. Default is 7 which selects run reports created in the past 7 days.
+# -f <input_file>: optional. Process the specified when this option is used. 
+# -d <input_dir>: optional. Process files in the specidied directory when this option is used.
+# -r <report_id>: optional. Add report DI to the report filename when specified. 
+
+function usage {
+    echo "Usage: select_parallel_log.sh -p <past_days> -f <input_file> -d <input_dir> -r <report_id>"
+    echo "Options:"
+    echo " -p <past_days>: optional. Default is 7 which selects run reports created in the past 7 days."
+    echo " -f <input_file>: optional. Process the specified when this option is used." 
+    echo " -d <input_dir>: optional. Process files in the specidied directory when this option is used."
+    echo " -r <report_id>: optional. Add report DI to the report filename when specified."
+}
 
 LOG_PATH=~/import/*/rundata/
 PAST_DAYS=7
 REPORT_DATE=`date "+%Y%m%d"`
 OUTPUT_DIR=~/import/parallel_log_analysis
+LOG_FILE=""
+LOG_DIR=""
 
-while getopts "d:" option
+while getopts "d:f:p:r:h" option
 do
  case "${option}"
  in
- d) PAST_DAYS=${OPTARG} ;;
+ p) PAST_DAYS=${OPTARG} ;;
+ f) LOG_FILE=${OPTARG} ;;
+ d) LOG_DIR=${OPTARG} ;;
+ r) RPT_ID=${OPTARG} ;;
+ h) usage
+    exit 
+    ;;
  \?)
     echo "Invalid option: -$OPTARG" >&2
+    usage
     exit
     ;;
  esac
 done
 
-echo $PAST_DAYS
+#echo $PAST_DAYS
+#echo $LOG_FILE
 
-OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}-${PAST_DAYS}_paired_entries.txt
-
-# find log files created in the past 7 days and get the matched lines
-find $LOG_PATH -mtime -${PAST_DAYS} -type f -exec grep "create_cid_field : new" -A1 {} \+ | sed "/--$/d" | sed "s/.txt-/.txt:/g" > ${OUTPUT_FILE}
+if [[ -f "$LOG_FILE" ]]; then
+  filename=`basename $LOG_FILE`
+  OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}_${filename}_paired_entries.txt
+  #echo $OUTPUT_FILE
+  grep "create_cid_field : new" -A1 $LOG_FILE > ${OUTPUT_FILE}
+elif [[ -d "$LOG_DIR" ]]; then
+  if [ -z "$RPT_ID" ]; then
+    dir_name=`dirname $LOG_DIR`
+    RPT_ID=`basename $dir_name`
+  fi
+  #echo $RPT_ID
+  OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}_${RPT_ID}_paired_entries.txt
+  #echo $OUTPUT_FILE
+  grep "create_cid_field : new" -A1 $LOG_DIR/*.txt | sed "/--$/d" | sed "s/.txt-/.txt:/g" > ${OUTPUT_FILE}
+else
+  OUTPUT_FILE=${OUTPUT_DIR}/${REPORT_DATE}-${PAST_DAYS}_paired_entries.txt
+  # find log files created in the past 7 days and get the matched lines
+  find $LOG_PATH -mtime -${PAST_DAYS} -type f -exec grep "create_cid_field : new" -A1 {} \+ | sed "/--$/d" | sed "s/.txt-/.txt:/g" > ${OUTPUT_FILE}
+fi
 
 PIPFILE="/apps/htmm/zephir-services/Pipfile"
 SCRIPT="/apps/htmm/zephir-services/scripts/check_cid_difference.py"


### PR DESCRIPTION
@cscollett Hi Charlie,
The paired Shell and Python scripts are designed to
* Select parallel testing log entries from the run reports
* Compare the CID mining results from the current and the new algorithms
* Categorize the comparison results into 4 categories
* Output the comparison results to a ":" delimited tex file

The options defined in the Shell script can be used to specified input and output files.

Please review and let me know if you have questions.

Thank you

Jing