### PR TITLE
remove timeout from cid_inquiry

### DIFF
--- a/cid-minting/cid_inquiry.py
+++ b/cid-minting/cid_inquiry.py
@@ -133,7 +133,6 @@ def main():
 
         exit(0)
 
-    process_timestamp = time.time()
     run_process = True
     while run_process:
         for file in os.listdir(cid_inquiry_data_dir):
@@ -144,16 +143,11 @@ def main():
                 ocns_from_filename = file[37:][:-4]
                 ocns_list = convert_comma_separated_str_to_int_list(ocns_from_filename)
                 results = cid_inquiry(ocns_list, DB_CONNECT_STR, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
+
                 with open(output_filename, 'w') as output_file:
                     output_file.write(json.dumps(results))
 
                 os.rename(output_filename, done_filename)
-
-                process_timestamp = time.time()
-        else:
-            # end loop if there are no input data for 10 min
-            if (time.time() - process_timestamp > 600):
-                run_process = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@cscollett Hi Charlie,

This is to remove the timer from the cid_inquiry. 

Previously cid_inquiry stops itself when there are no files in the data directory for 10 minutes. When Prep pre-processing large files using xmlint, it may take a while for the first CID inquiry to come in. Because the timer is set when Prep is started, when pre-processing takes longer than 10 minutes, the cid_inquiry process will stop. 

The timer will also fail when processing large file with records that do not have OCNs. So I am removing the timer from cid_inquiry and leave start/stop cid_inquiry for the caller to handle.

Please review and let me know if you have questions.

Thank you

Jing