### PR TITLE
Fix remove not needed error lines

### DIFF
--- a/scripts/check_cid_difference.py
+++ b/scripts/check_cid_difference.py
@@ -21,8 +21,14 @@ with open(input_file) as fp:
             continue
         count += 1
         if count % 2 == 0:
+            if "create_cid_field : old" not in line and "ERROR 35:" not in line:
+                print ("Unexpected log entry: {}".format(line))
+                exit(1)
             old_cids.append(line)
         else:
+            if "create_cid_field : new" not in line:
+                print ("Unexpected log entry: {}".format(line))
+                exit(1)
             new_cids.append(line)
 
 if (len(new_cids) != len(old_cids)):

--- a/scripts/check_cid_difference.py
+++ b/scripts/check_cid_difference.py
@@ -17,6 +17,8 @@ new_cids = []
 old_cids = []
 with open(input_file) as fp:
    for line in fp:
+        if "ERROR" in line and "ERROR 35:" not in line:
+            continue
         count += 1
         if count % 2 == 0:
             old_cids.append(line)


### PR DESCRIPTION
@cscollett Hi Charlie,
Here are the changes:
1. Exclude error lines that are not "ERROR: 35"
2. Report error when log entires from new and current procedures are not paired 

Please review and let me know if you have questions.

Thank you

Jing