### PR TITLE
18415 tact transformer 2

### DIFF
--- a/tact_project/README.md
+++ b/tact_project/README.md
@@ -1,0 +1,36 @@
+## How to test
+
+### Test data files
+The test data files are in the `indata_testdata/{publisher}` directory, one file for each publisher under each publisher's sub-dir:
+
+acm/ACM_UC_Report_Input.csv
+cob/CoB_input_21_23.csv
+csp/CSP_input.csv
+cup/CUP_input_June2021.csv
+elsevier/Elsevier_202107_Input.csv
+plos/PLOS_2021_June.csv
+springer/Springer_input_202106.csv
+trs/Royal_Society_2021_07.csv
+
+### Copy the directory and files to the `indata` directory:
+
+cp -r indata_testdata indata
+
+### Run the transformer script
+
+pipenv run python tact_transformer.py
+
+### Compare output files
+Output files are in the `outputis/{publisher}` directory. A base output file for each publisher is save under the publisher's sub-dir with a `.base` extension.
+
+acm/ACM_output.csv.base
+cob/CoB_output.csv.base
+csp/CSP_ouput.csv.base
+cup/CUP_output.csv.base
+elsevier/Elsevier_output.csv.base
+plos/PLOS_output.csv.base
+springer/Springer_output.csv.base
+trs/Royal_Society_output.csv.base
+
+Compare the output from recent run with the base output to make sure your code changes did affect the output. If yes, then provide a fix to either the code or the base output accordingly.
+

--- a/tact_project/tact_transformer.py
+++ b/tact_project/tact_transformer.py
@@ -8,17 +8,9 @@ from csv import DictReader
 from csv import DictWriter
 from pathlib import Path
 from pathlib import PurePosixPath
+import importlib
 
 from utils import *
-
-import acm_mapper
-import elsevier_mapper
-import cob_mapper
-import csp_mapper
-import springer_mapper
-import cup_mapper
-import plos_mapper
-import trs_mapper
 
 publishers = [
         "ACM",
@@ -99,38 +91,11 @@ institution_id = {
 
 def define_variables(publisher):
     publisher = publisher.lower()
-    if publisher == "acm":
-        source_fieldnames = acm_mapper.source_fieldnames
-        mapping_function = getattr(acm_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_acm']
-    elif publisher == "cob":
-        source_fieldnames = cob_mapper.source_fieldnames
-        mapping_function = getattr(cob_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_cob']
-    elif publisher == "csp":
-        source_fieldnames = csp_mapper.source_fieldnames
-        mapping_function = getattr(csp_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_csp']
-    elif publisher == "cup":
-        source_fieldnames = cup_mapper.source_fieldnames
-        mapping_function = getattr(cup_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_cup']
-    elif publisher == "elsevier":
-        source_fieldnames = elsevier_mapper.source_fieldnames
-        mapping_function = getattr(elsevier_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_elsevier']
-    elif publisher == "plos":
-        source_fieldnames = plos_mapper.source_fieldnames
-        mapping_function = getattr(plos_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_plos']
-    elif publisher == "springer":
-        source_fieldnames = springer_mapper.source_fieldnames
-        mapping_function = getattr(springer_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_springer']
-    elif publisher == "trs":
-        source_fieldnames = trs_mapper.source_fieldnames
-        mapping_function = getattr(trs_mapper, "source_to_output_mapping")
-        transform_function = globals()['transform_trs']
+    mapper = importlib.import_module("{}_mapper".format(publisher))
+
+    source_fieldnames = mapper.source_fieldnames
+    mapping_function = getattr(mapper, "source_to_output_mapping")
+    transform_function = globals()["transform_{}".format(publisher)]
 
     return source_fieldnames, mapping_function, transform_function
 


### PR DESCRIPTION
@cscollett Hi Charlie,
I am now using importlib to import the mapper modules. You can use a string variable to define module name in this case. For example:
mapper = importlib.import_module("{}_mapper".format(publisher))

The code is much simpler now. Please review and thank you for the suggestions.

Jing