### PR TITLE
exclude shadow records from the zephir items list

### DIFF
--- a/marctools/zephir_db_utils.py
+++ b/marctools/zephir_db_utils.py
@@ -16,6 +16,7 @@ SELECT_ZEPHIR_IDS = """select CAST(cid as UNSIGNED) cid, identifier as oclc,
   inner join zephir_identifiers zi on zir.identifier_autoid = zi.autoid
   where zr.autoid between :start_autoid and :end_autoid
   and zi.type = 'oclc'
+  and zr.shadow_date is null
   order by cid, id, identifier
 """
 


### PR DESCRIPTION
@cscollett Hi Charlie,
The modified select query will be used by the merge/split analysis scripts to generate the full list of HTID and OCN pairs. The change is to not include HTID with a shadow date.

Please review and let me know if you have questions.

Thank you

Jing