### PR TITLE
19730 cid minter

### DIFF
--- a/prepare_zephir_records/cid_minter/cid_inquiry_by_ocns.py
+++ b/prepare_zephir_records/cid_minter/cid_inquiry_by_ocns.py
@@ -6,11 +6,9 @@ import json
 import logging
 import time
 
-from prepare_zephir_records.lib.utils import db_connect_url
-from prepare_zephir_records.lib.utils import get_configs_by_filename
 
-from prepare_zephir_records.cid_minter.oclc_lookup import lookup_ocns_from_oclc
-from prepare_zephir_records.cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.oclc_lookup import lookup_ocns_from_oclc
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
 
 def cid_inquiry_by_ocns(ocns, zephirDb, primary_db_path, cluster_db_path):
     """Find Zephir clusters by given OCNs and their associated OCLC OCNs.
@@ -69,73 +67,4 @@ def convert_comma_separated_str_to_int_list(ocn_str):
 
     return int_list
 
-def usage(script_name):
-    print("Parameter error.")
-    print("Usage: {} env[dev|stg|prd] comma_separated_ocns".format(script_name))
-    print("{} dev 1,6567842,6758168,8727632".format(script_name))
 
-def main():
-    """ Retrieves Zephir clusters by OCNs.
-        Command line arguments:
-        argv[1]: Server environemnt (Required). Can be dev, stg, or prd.
-        argv[2]: List of OCNs (Optional).
-                 Comma separated strings without spaces in between any two values.
-                 For example: 1,6567842,6758168,8727632
-                 When OCNs present: 
-                   1. retrieves Zephir clusters by given OCNs;
-                   2. return Zephir clusters in JSON string.
-                 When OCNs is not present:
-                   1. find OCNs from the next input file;
-                   2. retrieves Zephir clusters by given OCNs;
-                   3. write Zephir clusters in JSON string to output file;
-                   4. repeat 1-3 indefinitely or when there are no input files for 10 minutes.
-    """
-
-    if (len(sys.argv) != 3):
-        usage(sys.argv[0])
-        exit(1)
-
-    env = sys.argv[1]
-    if env not in ["test", "dev", "stg", "prd"]:
-        usage(sys.argv[0])
-        exit(1)
-
-    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-    ROOT_PATH = os.path.dirname(ROOT_PATH)
-    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
-
-    zephir_db_config = get_configs_by_filename(CONFIG_PATH, "zephir_db")
-    db_connect_str = str(db_connect_url(zephir_db_config[env]))
-
-    cid_minting_config = get_configs_by_filename(CONFIG_PATH, "cid_minting")
-    primary_db_path = cid_minting_config["primary_db_path"]
-    cluster_db_path = cid_minting_config["cluster_db_path"]
-    logfile = cid_minting_config['logpath']
-    cid_inquiry_data_dir = cid_minting_config['cid_inquiry_data_dir']
-    cid_inquiry_done_dir = cid_minting_config['cid_inquiry_done_dir']
-
-    logging.basicConfig(
-            level=logging.DEBUG,
-            filename=logfile,
-            format="%(asctime)s %(levelname)-4s %(message)s",
-        )
-    logging.info("Start " + os.path.basename(__file__))
-    logging.info("Env: {}".format(env))
-
-    DB_CONNECT_STR = os.environ.get("OVERRIDE_DB_CONNECT_STR") or db_connect_str
-    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
-    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
-
-    zephirDb = ZephirDatabase(DB_CONNECT_STR)
-
-    if (len(sys.argv) == 3):
-        ocns_list = convert_comma_separated_str_to_int_list(sys.argv[2])
-
-        results = cid_inquiry_by_ocns(ocns_list, zephirDb, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
-        print(json.dumps(results))
-
-        exit(0)
-
-
-if __name__ == '__main__':
-    main()

--- a/prepare_zephir_records/cid_minter/cid_minter.py
+++ b/prepare_zephir_records/cid_minter/cid_minter.py
@@ -1,17 +1,9 @@
 import os
 import sys
 
-import environs
-import json
-import logging
-import time
-
-from prepare_zephir_records.lib.utils import db_connect_url
-from prepare_zephir_records.lib.utils import get_configs_by_filename
-
-from prepare_zephir_records.cid_minter.oclc_lookup import lookup_ocns_from_oclc
-from prepare_zephir_records.cid_minter.zephir_cluster_lookup import ZephirDatabase
-from prepare_zephir_records.cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
+from cid_minter.oclc_lookup import lookup_ocns_from_oclc
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
 
 class CidMinter:
     def __init__(self, config, ids):
@@ -28,92 +20,4 @@ class CidMinter:
         print(results)
         return results['min_cid']
 
-def convert_comma_separated_str_to_int_list(ocn_str):
-    int_list=[]
-    str_list = ocn_str.split(",")
-    for a_str in str_list:
-        try:
-            ocn = int(a_str)
-        except ValueError:
-            logging.error("ValueError: {}".format(a_str))
-            continue
-        if (ocn > 0):
-            int_list.append(ocn)
-        else:
-            logging.error("ValueError: {}".format(a_str))
 
-    return int_list
-
-def usage(script_name):
-    print("Parameter error.")
-    print("Usage: {} env[dev|stg|prd] comma_separated_ocns".format(script_name))
-    print("{} dev 1,6567842,6758168,8727632".format(script_name))
-
-def main():
-    """ Retrieves Zephir clusters by OCNs.
-        Command line arguments:
-        argv[1]: Server environemnt (Required). Can be dev, stg, or prd.
-        argv[2]: List of OCNs (Optional).
-                 Comma separated strings without spaces in between any two values.
-                 For example: 1,6567842,6758168,8727632
-                 When OCNs present: 
-                   1. retrieves Zephir clusters by given OCNs;
-                   2. return Zephir clusters in JSON string.
-    """
-
-    if (len(sys.argv) != 3):
-        usage(sys.argv[0])
-        exit(1)
-
-    env = sys.argv[1]
-    if env not in ["test", "dev", "stg", "prd"]:
-        usage(sys.argv[0])
-        exit(1)
-
-    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
-
-    zephir_db_config = get_configs_by_filename(CONFIG_PATH, "zephir_db")
-    db_connect_str = str(db_connect_url(zephir_db_config[env]))
-
-    cid_minting_config = get_configs_by_filename("config", "cid_minting")
-    primary_db_path = cid_minting_config["primary_db_path"]
-    cluster_db_path = cid_minting_config["cluster_db_path"]
-    logfile = cid_minting_config['logpath']
-    cid_inquiry_data_dir = cid_minting_config['cid_inquiry_data_dir']
-    cid_inquiry_done_dir = cid_minting_config['cid_inquiry_done_dir']
-
-    logging.basicConfig(
-            level=logging.DEBUG,
-            filename=logfile,
-            format="%(asctime)s %(levelname)-4s %(message)s",
-        )
-    logging.info("Start " + os.path.basename(__file__))
-    logging.info("Env: {}".format(env))
-
-    DB_CONNECT_STR = os.environ.get("OVERRIDE_DB_CONNECT_STR") or db_connect_str
-    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
-    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
-
-    config = {
-        "zephirdb_connect_str": DB_CONNECT_STR,
-        "leveldb_primary_path": PRIMARY_DB_PATH,
-        "leveldb_cluster_path": CLUSTER_DB_PATH,
-    }
-
-    zephirDb = ZephirDatabase(DB_CONNECT_STR)
-
-    if (len(sys.argv) == 3):
-        ocns_list = convert_comma_separated_str_to_int_list(sys.argv[2])
-        print("output from CidMinter")
-        ids = {
-            "ocns": ocns_list,
-        }
-        cid_minter = CidMinter(config, ids)
-        cid = cid_minter.mint_cid() 
-        print(cid)
-        exit(0)
-
-
-if __name__ == '__main__':
-    main()

--- a/prepare_zephir_records/cid_minter/local_cid_minter.py
+++ b/prepare_zephir_records/cid_minter/local_cid_minter.py
@@ -8,15 +8,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.exc import IntegrityError
 
-import environs
 import logging
-import json
 
-from lib.utils import db_connect_url
-from lib.utils import get_configs_by_filename
-from zephir_cluster_lookup import list_to_str
-from zephir_cluster_lookup import valid_sql_in_clause_str
-from zephir_cluster_lookup import invalid_sql_in_clause_str
+from cid_minter.zephir_cluster_lookup import list_to_str
+from cid_minter.zephir_cluster_lookup import valid_sql_in_clause_str
+from cid_minter.zephir_cluster_lookup import invalid_sql_in_clause_str
 
 
 def prepare_database(db_connect_str):
@@ -90,110 +86,10 @@ def insert_a_record(session, record):
         session.flush()
     except IntegrityError as e:
         session.rollback()
-        logging.error("IntegrityError adding record")
-        logging.info("type: {}, value: {}, cid: {} ".format(record.type, record.identifier, record.cid))
+        #logging.error("IntegrityError adding record")
+        #logging.info("type: {}, value: {}, cid: {} ".format(record.type, record.identifier, record.cid))
         return "IntegrityError"
     else:
         session.commit()
         return "Success"
 
-def usage(script_name):
-        print("Usage: {} env[dev|stg|prd] action[read|write] type[ocn|sysid] data[comma_separated_ocns|sys_id] cid".format(script_name))
-        print("{} dev read ocn 8727632,32882115".format(script_name))
-        print("{} dev read sysid uc1234567".format(script_name))
-        print("{} dev write ocn 30461866 011323406".format(script_name))
-        print("{} dev write sysid uc1234567 011323407".format(script_name))
-
-
-def main():
-    """ Performs read and write actions to the cid_minting_store table which stores the identifier and CID in pairs.
-        Command line arguments:
-        argv[1]: Server environemnt (Required). Can be test, dev, stg, or prd.
-        argv[2]: Action. Can only be 'read' or 'write'
-        argv[3]: Data type. Can only be 'ocn' and 'sysid'
-        argv[4]: Data. OCNs or a local system ID.
-                 OCNs format:
-                   Comma separated strings without spaces in between any two values.
-                   For example: 8727632,32882115
-                 Local system ID: a string.
-        argv[5]: A CID. Only required when Action='write'
-    """
-
-    if (len(sys.argv) != 5 and len(sys.argv) != 6):
-        print("Parameter error.")
-        usage(sys.argv[0])
-        exit(1)
-
-    env = sys.argv[1]
-    action = sys.argv[2]
-    data_type = sys.argv[3]
-    data = sys.argv[4]
-    cid = None
-    if len(sys.argv) == 6:
-        cid = sys.argv[5]
-
-    if env not in ["test", "dev", "stg", "prd"]:
-        usage(sys.argv[0])
-        exit(1)
-
-    if action not in ["read", "write"]:
-        usage(sys.argv[0])
-        exit(1)
-
-    if data_type not in ["ocn", "sysid"]:
-        usage(sys.argv[0])
-        exit(1)
-
-    if action == "write" and cid == None:
-        usage(sys.argv[0])
-        exit(1)
-
-    cmd_options = "cmd options: {} {} {} {}".format(env, action, data_type, data)
-    if cid:
-        cmd_options += " " + cid
-
-    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
-
-    configs= get_configs_by_filename(CONFIG_PATH, 'cid_minting')
-    logfile = configs['logpath']
-    db_config = str(db_connect_url(configs[env]['minter_db']))
-
-    logging.basicConfig(
-            level=logging.DEBUG,
-            filename=logfile,
-            format="%(asctime)s %(levelname)-4s %(message)s",
-        )
-    logging.info("Start " + os.path.basename(__file__))
-    logging.info(cmd_options)
-
-    DB_CONNECT_STR = os.environ.get('OVERRIDE_DB_CONNECT_STR') or db_config
-
-    db = prepare_database(DB_CONNECT_STR)
-    engine = db['engine']
-    session = db['session']
-    CidMintingStore = db['table']
-
-    results = {} 
-    if action == "read":
-        if data_type == "ocn":
-            results = find_cids_by_ocns(engine, data.split(","))
-
-        if data_type == "sysid":
-            results = find_cid_by_sysid(CidMintingStore, session, data)
-        
-        engine.dispose()
-        print(json.dumps(results))
-        exit(0)
-
-    if action == "write":
-        record = CidMintingStore(type=data_type, identifier=data, cid=cid)
-        inserted = insert_a_record(session, record)
-        engine.dispose()
-        if inserted != "Success":
-            exit(1)
-        else:
-            exit(0)
-
-if __name__ == "__main__":
-    main()

--- a/prepare_zephir_records/cid_minter/oclc_lookup.py
+++ b/prepare_zephir_records/cid_minter/oclc_lookup.py
@@ -6,8 +6,6 @@ import msgpack
 import plyvel
 import click
 
-from prepare_zephir_records.lib.utils import get_configs_by_filename
-
 # convenience methods for converting ints to and from bytes
 def int_to_bytes(inum):
     return inum.to_bytes((inum.bit_length() + 7) // 8, 'big')
@@ -317,43 +315,3 @@ def tests():
     ocns=[]
     assert get_clusters_by_ocns(ocns) == set()
 
-@click.command()
-@click.option('-t', '--test', is_flag=True, help="Will run a set of tests.")
-@click.argument('ocns', nargs=-1)
-def main(test, ocns):
-    """For a given list of OCNs, find all resolved OCNs clusters from the OCLC Concordance Table.
-
-    Provide the OCNs list in space separated integers, for example: 1 123.
-
-    cmd: pipenv run python oclc_lookup.py 1 123
-
-    returns: {(123, 18329830, 67524283), (1, 6567842, 9987701, 53095235, 433981287)}
-    """
-    if test:
-        click.echo("Running tests ...")
-        tests()
-        exit(0)
-
-    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-    ROOT_PATH = os.path.dirname(ROOT_PATH)
-    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
-
-    configs = get_configs_by_filename(CONFIG_PATH, "cid_minting")
-    primary_db_path = configs["primary_db_path"]
-    cluster_db_path = configs["cluster_db_path"]
-
-    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
-    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
-
-    ocns_list = list(int(ocn) for ocn in ocns)
-    if ocns_list:
-        clusters = get_clusters_by_ocns(ocns_list, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
-        click.echo(clusters)
-        exit(0)
-    else:
-        ctx = click.get_current_context()
-        click.echo(ctx.get_help())
-        exit(1)
-
-if __name__ == "__main__":
-    main()

--- a/prepare_zephir_records/cid_minter/tests/test_cid_inquiry_by_ocns.py
+++ b/prepare_zephir_records/cid_minter/tests/test_cid_inquiry_by_ocns.py
@@ -6,11 +6,10 @@ import pytest
 import plyvel
 import json
 
-from prepare_zephir_records.cid_minter.zephir_cluster_lookup import ZephirDatabase
-from prepare_zephir_records.cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
-from prepare_zephir_records.cid_inquiry_by_ocns import flat_and_dedup_sort_list
-from prepare_zephir_records.cid_inquiry_by_ocns import convert_comma_separated_str_to_int_list
-from prepare_zephir_records.cid_inquiry_by_ocns import main
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
+from cid_minter.cid_inquiry_by_ocns import flat_and_dedup_sort_list
+from cid_minter.cid_inquiry_by_ocns import convert_comma_separated_str_to_int_list
 
 """Test cid_inquiry_by_ocns() function which returns a dict with: 
   "iquiry_ocns": input ocns, list of integers.
@@ -539,58 +538,6 @@ def test_case_4_abc(setup_leveldb, setup_sqlite):
         assert result["cid_ocn_clusters"] == expected_zephir_clsuters[k]
         assert result["num_of_matched_zephir_clusters"] == expected_num_of_zephir_clsuters[k] 
         assert result["min_cid"] ==  expected_min_cid[k]
-
-# no argument
-def test_main_param_err_0(capsys, setup_leveldb, setup_sqlite):
-    with pytest.raises(SystemExit) as pytest_e:
-        main()
-    out, err = capsys.readouterr()
-    assert "Parameter error" in out
-    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
-
-# one argument
-def test_main_param_err_1(capsys, setup_leveldb, setup_sqlite):
-    with pytest.raises(SystemExit) as pytest_e:
-        sys.argv = ['dev']
-        main()
-    out, err = capsys.readouterr()
-    assert "Parameter error" in out
-    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
-
-# two arguments
-def test_main_param_err_2(capsys, setup_leveldb, setup_sqlite):
-    with pytest.raises(SystemExit) as pytest_e:
-        sys.argv = ['dev', '1']
-        main()
-    out, err = capsys.readouterr()
-    assert "Parameter error" in out
-    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
-
-# OCN: 300 (not in test db) 
-def test_main_not_in_test_db(capsys, setup_leveldb, setup_sqlite):
-    with pytest.raises(SystemExit) as pytest_e:
-        # env will be override by environment varaiable
-        sys.argv = ['', 'test', '300']
-        main()
-    out, err = capsys.readouterr()
-    expected = '{"inquiry_ocns": [300], "matched_oclc_clusters": [[300, 39867290, 39867383]], "num_of_matched_oclc_clusters": 1, "inquiry_ocns_zephir": [300, 39867290, 39867383], "cid_ocn_list": [], "cid_ocn_clusters": {}, "num_of_matched_zephir_clusters": 0, "min_cid": null}'
-
-    assert  expected in out 
-    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
-
-# OCNs: 217211158, 8727632 (test case 1&2 c)
-def test_main_in_test_db_2_clusters(capsys, setup_leveldb, setup_sqlite):
-    with pytest.raises(SystemExit) as pytest_e:
-        # env will be override by environment varaiable
-        sys.argv = ['', 'test', '217211158,8727632']
-        main()
-    out, err = capsys.readouterr()
-
-    expected = '{"inquiry_ocns": [217211158, 8727632], "matched_oclc_clusters": [[8727632, 24253253]], "num_of_matched_oclc_clusters": 1, "inquiry_ocns_zephir": [8727632, 24253253, 217211158], "cid_ocn_list": [{"cid": "000000280", "ocn": "217211158"}, {"cid": "000000280", "ocn": "25909"}, {"cid": "002492721", "ocn": "8727632"}], "cid_ocn_clusters": {"000000280": ["217211158", "25909"], "002492721": ["8727632"]}, "num_of_matched_zephir_clusters": 2, "min_cid": "000000280"}'
-
-    assert expected in out
-    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
-
 
 def test_flat_and_dedup_sort_list():
     input_list = {

--- a/prepare_zephir_records/cid_minter/tests/test_local_cid_minter.py
+++ b/prepare_zephir_records/cid_minter/tests/test_local_cid_minter.py
@@ -5,7 +5,7 @@ import pytest
 import environs
 import logging
 
-from local_cid_minter import prepare_database, find_all, find_by_identifier, find_query, insert_a_record, find_cids_by_ocns, find_cid_by_sysid, main
+from cid_minter.local_cid_minter import prepare_database, find_all, find_by_identifier, find_query, insert_a_record, find_cids_by_ocns, find_cid_by_sysid
 
 @pytest.fixture
 def create_test_db(data_dir, tmpdir, scope="session"):

--- a/prepare_zephir_records/cid_minter/tests/test_my_app.py
+++ b/prepare_zephir_records/cid_minter/tests/test_my_app.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from my_app import main
+from cid_minter.my_app import main
 
 def test_my_function(capsys):
     with pytest.raises(SystemExit) as pytest_e:

--- a/prepare_zephir_records/cid_minter/tests/test_oclc_lookup.py
+++ b/prepare_zephir_records/cid_minter/tests/test_oclc_lookup.py
@@ -11,7 +11,6 @@ from oclc_lookup import get_ocns_cluster_by_ocn
 from oclc_lookup import get_clusters_by_ocns
 from oclc_lookup import convert_set_to_list
 from oclc_lookup import lookup_ocns_from_oclc
-from oclc_lookup import main
 
 # TESTS
 def test_get_primary_ocn(setup):
@@ -219,35 +218,6 @@ def test_lookup_ocns_from_oclc(setup):
         assert result["inquiry_ocns"] == ocns
         assert result["matched_oclc_clusters"] == expected[k]["matched_oclc_clusters"]
         assert result["num_of_matched_oclc_clusters"] == expected[k]["num_of_matched_oclc_clusters"]
-
-# TEST cmd line options
-def test_main(setup):
-
-    runner = CliRunner()
-    result = runner.invoke(main)
-    assert result.exit_code == 1 
-    assert 'Usage' in result.output
-
-    result = runner.invoke(main, ['-t'])
-    #assert result.exit_code == 0 
-    assert 'Running tests ...' in result.output
-
-    result = runner.invoke(main, ['--test'])
-    #assert result.exit_code == 0
-    assert 'Running tests ...' in result.output
-
-    result = runner.invoke(main, ['1'])
-    assert result.output ==  '{(1, 6567842, 9987701, 53095235, 433981287)}\n'
-
-    result = runner.invoke(main, ['2'])
-    assert result.output == '{(2, 9772597, 35597370, 60494959, 813305061, 823937796, 1087342349)}\n'
-
-    result = runner.invoke(main, ['1', '2'])
-    assert result.output == '{(2, 9772597, 35597370, 60494959, 813305061, 823937796, 1087342349), (1, 6567842, 9987701, 53095235, 433981287)}\n'
-
-    # '123' is not in the test db
-    result = runner.invoke(main, ['123'])
-    assert result.output == 'set()\n'
 
 # FIXTURES
 @pytest.fixture

--- a/prepare_zephir_records/cid_minter/tests/test_oclc_lookup.py
+++ b/prepare_zephir_records/cid_minter/tests/test_oclc_lookup.py
@@ -5,12 +5,12 @@ import pytest
 import plyvel
 from click.testing import CliRunner
 
-from oclc_lookup import get_primary_ocn
-from oclc_lookup import get_ocns_cluster_by_primary_ocn
-from oclc_lookup import get_ocns_cluster_by_ocn
-from oclc_lookup import get_clusters_by_ocns
-from oclc_lookup import convert_set_to_list
-from oclc_lookup import lookup_ocns_from_oclc
+from cid_minter.oclc_lookup import get_primary_ocn
+from cid_minter.oclc_lookup import get_ocns_cluster_by_primary_ocn
+from cid_minter.oclc_lookup import get_ocns_cluster_by_ocn
+from cid_minter.oclc_lookup import get_clusters_by_ocns
+from cid_minter.oclc_lookup import convert_set_to_list
+from cid_minter.oclc_lookup import lookup_ocns_from_oclc
 
 # TESTS
 def test_get_primary_ocn(setup):

--- a/prepare_zephir_records/cid_minter/tests/test_sqlite.py
+++ b/prepare_zephir_records/cid_minter/tests/test_sqlite.py
@@ -1,5 +1,5 @@
 import pytest
-from create_sqlite_db import create_connection, execute_sql, insert_query, list_data
+from cid_minter.create_sqlite_db import create_connection, execute_sql, insert_query, list_data
 
 @pytest.fixture
 #def create_test_db(datadir):

--- a/prepare_zephir_records/cid_minter/tests/test_zephir_cluster_lookup.py
+++ b/prepare_zephir_records/cid_minter/tests/test_zephir_cluster_lookup.py
@@ -3,11 +3,11 @@ import os
 import pytest
 import environs
 
-from zephir_cluster_lookup import ZephirDatabase
-from zephir_cluster_lookup import valid_sql_in_clause_str
-from zephir_cluster_lookup import invalid_sql_in_clause_str
-from zephir_cluster_lookup import list_to_str
-from zephir_cluster_lookup import formatting_cid_id_clusters
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.zephir_cluster_lookup import valid_sql_in_clause_str
+from cid_minter.zephir_cluster_lookup import invalid_sql_in_clause_str
+from cid_minter.zephir_cluster_lookup import list_to_str
+from cid_minter.zephir_cluster_lookup import formatting_cid_id_clusters
 
 @pytest.fixture
 def create_test_db(data_dir, tmpdir, scope="session"):

--- a/prepare_zephir_records/cid_minter/zephir_cluster_lookup.py
+++ b/prepare_zephir_records/cid_minter/zephir_cluster_lookup.py
@@ -5,8 +5,8 @@ import re
 from sqlalchemy import create_engine
 from sqlalchemy import text
 
-from prepare_zephir_records.lib.utils import db_connect_url
-from prepare_zephir_records.lib.utils import get_configs_by_filename
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
 
 class Database:
     def __init__(self, db_connect_str):

--- a/prepare_zephir_records/read_write_zephir_records.py
+++ b/prepare_zephir_records/read_write_zephir_records.py
@@ -10,9 +10,9 @@ from pymarc import Record, Field
 
 import xml.dom.minidom
 
-from prepare_zephir_records.lib.utils import db_connect_url
-from prepare_zephir_records.lib.utils import get_configs_by_filename
-from prepare_zephir_records.cid_minter.cid_minter import CidMinter
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
+from cid_minter.cid_minter import CidMinter
 
 def output_marc_records(config, input_file, output_file, err_file):
     """Process input records and write records to output files based on specifications.

--- a/prepare_zephir_records/run_cid_inquiry_by_ocns.py
+++ b/prepare_zephir_records/run_cid_inquiry_by_ocns.py
@@ -1,0 +1,100 @@
+import os
+import sys
+
+import environs
+import json
+import logging
+import time
+
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
+
+from cid_minter.oclc_lookup import lookup_ocns_from_oclc
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
+
+def convert_comma_separated_str_to_int_list(ocn_str):
+    int_list=[]
+    str_list = ocn_str.split(",")
+    for a_str in str_list:
+        try:
+            ocn = int(a_str)
+        except ValueError:
+            logging.error("ValueError: {}".format(a_str))
+            continue
+        if (ocn > 0):
+            int_list.append(ocn)
+        else:
+            logging.error("ValueError: {}".format(a_str))
+
+    return int_list
+
+def usage(script_name):
+    print("Parameter error.")
+    print("Usage: {} env[dev|stg|prd] comma_separated_ocns".format(script_name))
+    print("{} dev 1,6567842,6758168,8727632".format(script_name))
+
+def main():
+    """ Retrieves Zephir clusters by OCNs.
+        Command line arguments:
+        argv[1]: Server environemnt (Required). Can be dev, stg, or prd.
+        argv[2]: List of OCNs (Optional).
+                 Comma separated strings without spaces in between any two values.
+                 For example: 1,6567842,6758168,8727632
+                 When OCNs present: 
+                   1. retrieves Zephir clusters by given OCNs;
+                   2. return Zephir clusters in JSON string.
+                 When OCNs is not present:
+                   1. find OCNs from the next input file;
+                   2. retrieves Zephir clusters by given OCNs;
+                   3. write Zephir clusters in JSON string to output file;
+                   4. repeat 1-3 indefinitely or when there are no input files for 10 minutes.
+    """
+
+    if (len(sys.argv) != 3):
+        usage(sys.argv[0])
+        exit(1)
+
+    env = sys.argv[1]
+    if env not in ["test", "dev", "stg", "prd"]:
+        usage(sys.argv[0])
+        exit(1)
+
+    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
+
+    zephir_db_config = get_configs_by_filename(CONFIG_PATH, "zephir_db")
+    db_connect_str = str(db_connect_url(zephir_db_config[env]))
+
+    cid_minting_config = get_configs_by_filename(CONFIG_PATH, "cid_minting")
+    primary_db_path = cid_minting_config["primary_db_path"]
+    cluster_db_path = cid_minting_config["cluster_db_path"]
+    logfile = cid_minting_config['logpath']
+    cid_inquiry_data_dir = cid_minting_config['cid_inquiry_data_dir']
+    cid_inquiry_done_dir = cid_minting_config['cid_inquiry_done_dir']
+
+    logging.basicConfig(
+            level=logging.DEBUG,
+            filename=logfile,
+            format="%(asctime)s %(levelname)-4s %(message)s",
+        )
+    logging.info("Start " + os.path.basename(__file__))
+    logging.info("Env: {}".format(env))
+
+    DB_CONNECT_STR = os.environ.get("OVERRIDE_DB_CONNECT_STR") or db_connect_str
+    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
+    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
+
+    zephirDb = ZephirDatabase(DB_CONNECT_STR)
+
+    if (len(sys.argv) == 3):
+        ocns_list = convert_comma_separated_str_to_int_list(sys.argv[2])
+
+        results = cid_inquiry_by_ocns(ocns_list, zephirDb, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
+        print(json.dumps(results))
+
+        exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/prepare_zephir_records/run_cid_minter.py
+++ b/prepare_zephir_records/run_cid_minter.py
@@ -1,0 +1,105 @@
+import os
+import sys
+
+import environs
+import json
+import logging
+import time
+
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
+
+from cid_minter.oclc_lookup import lookup_ocns_from_oclc
+from cid_minter.zephir_cluster_lookup import ZephirDatabase
+from cid_minter.cid_inquiry_by_ocns import cid_inquiry_by_ocns
+from cid_minter.cid_minter import CidMinter 
+
+def convert_comma_separated_str_to_int_list(ocn_str):
+    int_list=[]
+    str_list = ocn_str.split(",")
+    for a_str in str_list:
+        try:
+            ocn = int(a_str)
+        except ValueError:
+            logging.error("ValueError: {}".format(a_str))
+            continue
+        if (ocn > 0):
+            int_list.append(ocn)
+        else:
+            logging.error("ValueError: {}".format(a_str))
+
+    return int_list
+
+def usage(script_name):
+    print("Parameter error.")
+    print("Usage: {} env[dev|stg|prd] comma_separated_ocns".format(script_name))
+    print("{} dev 1,6567842,6758168,8727632".format(script_name))
+
+def main():
+    """ Retrieves Zephir clusters by OCNs.
+        Command line arguments:
+        argv[1]: Server environemnt (Required). Can be dev, stg, or prd.
+        argv[2]: List of OCNs (Optional).
+                 Comma separated strings without spaces in between any two values.
+                 For example: 1,6567842,6758168,8727632
+                 When OCNs present: 
+                   1. retrieves Zephir clusters by given OCNs;
+                   2. return Zephir clusters in JSON string.
+    """
+
+    if (len(sys.argv) != 3):
+        usage(sys.argv[0])
+        exit(1)
+
+    env = sys.argv[1]
+    if env not in ["test", "dev", "stg", "prd"]:
+        usage(sys.argv[0])
+        exit(1)
+
+    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
+
+    zephir_db_config = get_configs_by_filename(CONFIG_PATH, "zephir_db")
+    db_connect_str = str(db_connect_url(zephir_db_config[env]))
+
+    cid_minting_config = get_configs_by_filename("config", "cid_minting")
+    primary_db_path = cid_minting_config["primary_db_path"]
+    cluster_db_path = cid_minting_config["cluster_db_path"]
+    logfile = cid_minting_config['logpath']
+    cid_inquiry_data_dir = cid_minting_config['cid_inquiry_data_dir']
+    cid_inquiry_done_dir = cid_minting_config['cid_inquiry_done_dir']
+
+    logging.basicConfig(
+            level=logging.DEBUG,
+            filename=logfile,
+            format="%(asctime)s %(levelname)-4s %(message)s",
+        )
+    logging.info("Start " + os.path.basename(__file__))
+    logging.info("Env: {}".format(env))
+
+    DB_CONNECT_STR = os.environ.get("OVERRIDE_DB_CONNECT_STR") or db_connect_str
+    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
+    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
+
+    config = {
+        "zephirdb_connect_str": DB_CONNECT_STR,
+        "leveldb_primary_path": PRIMARY_DB_PATH,
+        "leveldb_cluster_path": CLUSTER_DB_PATH,
+    }
+
+    zephirDb = ZephirDatabase(DB_CONNECT_STR)
+
+    if (len(sys.argv) == 3):
+        ocns_list = convert_comma_separated_str_to_int_list(sys.argv[2])
+        print("output from CidMinter")
+        ids = {
+            "ocns": ocns_list,
+        }
+        cid_minter = CidMinter(config, ids)
+        cid = cid_minter.mint_cid() 
+        print(cid)
+        exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/prepare_zephir_records/run_local_cid_minter.py
+++ b/prepare_zephir_records/run_local_cid_minter.py
@@ -1,0 +1,115 @@
+import os
+from os.path import join, dirname
+import sys
+
+import environs
+import logging
+import json
+
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
+from cid_minter.local_cid_minter import prepare_database
+from cid_minter.local_cid_minter import find_cids_by_ocns
+from cid_minter.local_cid_minter import find_cid_by_sysid
+from cid_minter.local_cid_minter import insert_a_record
+from cid_minter.local_cid_minter import invalid_sql_in_clause_str
+
+def usage(script_name):
+        print("Usage: {} env[dev|stg|prd] action[read|write] type[ocn|sysid] data[comma_separated_ocns|sys_id] cid".format(script_name))
+        print("{} dev read ocn 8727632,32882115".format(script_name))
+        print("{} dev read sysid uc1234567".format(script_name))
+        print("{} dev write ocn 30461866 011323406".format(script_name))
+        print("{} dev write sysid uc1234567 011323407".format(script_name))
+
+def main():
+    """ Performs read and write actions to the cid_minting_store table which stores the identifier and CID in pairs.
+        Command line arguments:
+        argv[1]: Server environemnt (Required). Can be test, dev, stg, or prd.
+        argv[2]: Action. Can only be 'read' or 'write'
+        argv[3]: Data type. Can only be 'ocn' and 'sysid'
+        argv[4]: Data. OCNs or a local system ID.
+                 OCNs format:
+                   Comma separated strings without spaces in between any two values.
+                   For example: 8727632,32882115
+                 Local system ID: a string.
+        argv[5]: A CID. Only required when Action='write'
+    """
+
+    if (len(sys.argv) != 5 and len(sys.argv) != 6):
+        print("Parameter error.")
+        usage(sys.argv[0])
+        exit(1)
+
+    env = sys.argv[1]
+    action = sys.argv[2]
+    data_type = sys.argv[3]
+    data = sys.argv[4]
+    cid = None
+    if len(sys.argv) == 6:
+        cid = sys.argv[5]
+
+    if env not in ["test", "dev", "stg", "prd"]:
+        usage(sys.argv[0])
+        exit(1)
+
+    if action not in ["read", "write"]:
+        usage(sys.argv[0])
+        exit(1)
+
+    if data_type not in ["ocn", "sysid"]:
+        usage(sys.argv[0])
+        exit(1)
+
+    if action == "write" and cid == None:
+        usage(sys.argv[0])
+        exit(1)
+
+    cmd_options = "cmd options: {} {} {} {}".format(env, action, data_type, data)
+    if cid:
+        cmd_options += " " + cid
+
+    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
+
+    configs= get_configs_by_filename(CONFIG_PATH, 'cid_minting')
+    logfile = configs['logpath']
+    db_config = str(db_connect_url(configs[env]['minter_db']))
+
+    logging.basicConfig(
+            level=logging.DEBUG,
+            filename=logfile,
+            format="%(asctime)s %(levelname)-4s %(message)s",
+        )
+    logging.info("Start " + os.path.basename(__file__))
+    logging.info(cmd_options)
+
+    DB_CONNECT_STR = os.environ.get('OVERRIDE_DB_CONNECT_STR') or db_config
+
+    db = prepare_database(DB_CONNECT_STR)
+    engine = db['engine']
+    session = db['session']
+    CidMintingStore = db['table']
+
+    results = {} 
+    if action == "read":
+        if data_type == "ocn":
+            results = find_cids_by_ocns(engine, data.split(","))
+
+        if data_type == "sysid":
+            results = find_cid_by_sysid(CidMintingStore, session, data)
+        
+        engine.dispose()
+        print(json.dumps(results))
+        exit(0)
+
+    if action == "write":
+        record = CidMintingStore(type=data_type, identifier=data, cid=cid)
+        inserted = insert_a_record(session, record)
+        engine.dispose()
+        if inserted != "Success":
+            exit(1)
+        else:
+            exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/prepare_zephir_records/run_oclc_lookup.py
+++ b/prepare_zephir_records/run_oclc_lookup.py
@@ -1,0 +1,195 @@
+import sys
+import os
+
+import environs
+import msgpack
+import plyvel
+import click
+
+from lib.utils import get_configs_by_filename
+from cid_minter.oclc_lookup import get_primary_ocn
+from cid_minter.oclc_lookup import get_ocns_cluster_by_ocn
+from cid_minter.oclc_lookup import get_ocns_cluster_by_primary_ocn
+from cid_minter.oclc_lookup import get_clusters_by_ocns
+
+def tests(primary_db_path, cluster_db_path):
+    clusters_raw = {'1': [6567842, 9987701, 53095235, 433981287],
+            '1000000000': None,
+            '2': [9772597, 35597370, 60494959, 813305061, 823937796, 1087342349],
+            '4': [518119215],
+            '17216714': [535434196],
+            }
+
+    clusters = {'1': [6567842, 9987701, 53095235, 433981287, 1],
+            '1000000000': [1000000000],
+            '2': [2, 9772597, 35597370, 60494959, 813305061, 823937796, 1087342349],
+            '4': [4, 518119215],
+            '17216714': [17216714, 535434196],
+            }
+    set_1 = set([tuple(sorted(clusters['1']))])
+    set_10 = set([tuple(sorted(clusters['1000000000']))])
+    set_2 = set([tuple(sorted(clusters['2']))])
+
+    print("#### testing get_primary_ocn(ocn, primary_db_path)")
+    ocn = 1000000000
+    assert get_primary_ocn(ocn, primary_db_path) == 1000000000
+
+    ocn = 1
+    assert get_primary_ocn(ocn, primary_db_path) == 1
+
+    ocn = 6567842
+    assert get_primary_ocn(ocn, primary_db_path) == 1
+
+    ocn = 1234567890
+    result = get_primary_ocn(ocn, primary_db_path)
+    print(f"incoming ocn={ocn} - primary ocn: {result}")
+    assert get_primary_ocn(ocn, primary_db_path) == 1234567890
+
+    ocn = None
+    assert get_primary_ocn(ocn, primary_db_path) == None
+    print("**** finished testing get_primary_ocn")
+
+    print("#### testing get_ocns_cluster_by_primary_ocn(primary_ocn)")
+    print("should return raw clusters without primary ocn in the cluster-db")
+    '''     when primary_ocn=1000000000, return None
+            when primary_ocn=1, return: [433981287, 6567842, 53095235, 9987701]
+            when primary_ocn=4, return: [518119215]
+            when primary_ocn=518119215, return: None
+            when primary_ocn=1234567890, return: None
+    '''
+    primary_ocn = 1000000000
+    assert get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path) == None
+
+    primary_ocn = 1
+    cluster = get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path)
+    print("cluster: {}".format(cluster))
+    print("sorted:  {}".format(sorted(cluster)))
+    assert sorted(cluster) == sorted(clusters_raw['1'])
+
+    primary_ocn = 4 
+    cluster = get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path)
+    print("cluster: {}".format(cluster))
+    print("sorted:  {}".format(sorted(cluster)))
+    assert sorted(cluster) == sorted(clusters_raw['4'])
+
+    primary_ocn = 518119215     # a previous ocn
+    assert get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path) == None
+
+    primary_ocn = 1234567890  # valid ocn
+    result= get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path)
+    print(f"cluster for ocn={primary_ocn}: {result}")
+    assert get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path) == None
+
+    primary_ocn = None
+    assert get_ocns_cluster_by_primary_ocn(primary_ocn, cluster_db_path) == None
+    print("**** finished testing get_ocns_cluster_by_primary_ocn(primary_ocn)")
+
+    print("#### testing get_ocns_cluster_by_ocn: returning list of integers")
+    print("should return clusters with the primary ocn")
+    '''
+        when ocn=1, return: [1, 433981287, 6567842, 53095235, 9987701]
+        when ocn=6567842, return: [1, 433981287, 6567842, 53095235, 9987701]
+        when ocn=4, return: [4, 518119215]
+        when ocn=1000000000, return: [1000000000] (a cluster without previous OCNs)
+        when ocn=1234567890, return: None (for an invalid ocn)
+    '''
+    ocn = 1
+    cluster = get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path)
+    print(cluster)
+    assert sorted(get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path)) == sorted(clusters['1'])
+
+    ocn = 6567842    # previous ocn
+    assert sorted(get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path)) == sorted(clusters['1'])
+
+    ocn = 4 
+    assert sorted(get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path)) == sorted(clusters['4'])
+
+    ocn = 1000000000
+    assert get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path) == [1000000000]
+
+    ocn = 1234567890 # valid ocn
+    result= get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path)
+    assert get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path) == [1234567890]
+
+    ocn = None
+    assert get_ocns_cluster_by_ocn(ocn, primary_db_path, cluster_db_path) == None
+    print("**** finished testing get_ocns_cluster_by_ocn")
+
+    print("#### testing  get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)")
+    ocns=[1]    # resolve to cluster[1]
+    clusters = get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)
+    print(clusters)
+    print(set_1)
+    assert clusters ^ set_1 == set()
+
+    ocns=[1000000000, 1000000000]    #  resolve to cluster[1000000000]
+    clusters = get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)
+    print(clusters)
+    print(set_10)
+    assert clusters ^ set_10 == set()
+
+    ocns=[1, 1000000000]    #    resolve to 2 ocn clusters
+    clusters = get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)
+    print(clusters)
+    print(set_1)
+    print(set_10)
+    assert clusters ^ (set_1 | set_10) == set()
+
+    ocns=[1, 1, 53095235, 2, 12345678901, 1000000000]
+    clusters = get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)
+    print(clusters)
+    print(set_1)
+    print(set_2)
+    assert clusters ^ (set_1 | set_2 | set_10) == set()
+
+    ocns=[1234567890]
+    result= get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path)
+    print(result)
+    assert get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path) == {(1234567890,)}
+
+    ocns=[1234567890, 12345678901]
+    assert get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path) == {(1234567890,)}
+
+    ocns=[]
+    assert get_clusters_by_ocns(ocns, primary_db_path, cluster_db_path) == set()
+
+@click.command()
+@click.option('-t', '--test', is_flag=True, help="Will run a set of tests.")
+@click.argument('ocns', nargs=-1)
+def main(test, ocns):
+    """For a given list of OCNs, find all resolved OCNs clusters from the OCLC Concordance Table.
+
+    Provide the OCNs list in space separated integers, for example: 1 123.
+
+    cmd: pipenv run python oclc_lookup.py 1 123
+
+    returns: {(123, 18329830, 67524283), (1, 6567842, 9987701, 53095235, 433981287)}
+    """
+
+    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
+
+    configs = get_configs_by_filename(CONFIG_PATH, "cid_minting")
+    primary_db_path = configs["primary_db_path"]
+    cluster_db_path = configs["cluster_db_path"]
+
+    PRIMARY_DB_PATH = os.environ.get("OVERRIDE_PRIMARY_DB_PATH") or primary_db_path
+    CLUSTER_DB_PATH = os.environ.get("OVERRIDE_CLUSTER_DB_PATH") or cluster_db_path
+
+    if test:
+        click.echo("Running tests ...")
+        tests(PRIMARY_DB_PATH, CLUSTER_DB_PATH)
+        exit(0)
+
+    ocns_list = list(int(ocn) for ocn in ocns)
+    if ocns_list:
+        clusters = get_clusters_by_ocns(ocns_list, PRIMARY_DB_PATH, CLUSTER_DB_PATH)
+        click.echo(clusters)
+        exit(0)
+    else:
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/prepare_zephir_records/run_zephir_cluster_lookup.py
+++ b/prepare_zephir_records/run_zephir_cluster_lookup.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import re
+
+from sqlalchemy import create_engine
+from sqlalchemy import text
+
+from lib.utils import db_connect_url
+from lib.utils import get_configs_by_filename
+from cid_minter.zephir_cluster_lookup import  ZephirDatabase:
+
+def main():
+    if (len(sys.argv) > 1):
+        env = sys.argv[1]
+    else:
+        env = "test"
+
+    ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_PATH = os.path.join(ROOT_PATH, 'config')
+
+    configs= get_configs_by_filename(CONFIG_PATH, 'zephir_db')
+    print(configs)
+
+    db_conn_str = str(db_connect_url(configs[env]))
+    zephirDb = ZephirDatabase(db_conn_str)
+
+    ocns_list = [6758168, 15437990, 5663662, 33393343, 28477569, 8727632]
+    print("Inquiry OCNs: {}".format(ocns_list))
+    results = zephirDb.zephir_clusters_lookup(ocns_list)
+    print(results)
+
+    sysid_list = ['pur63733', 'nrlf.b100608668']
+    results = zephirDb.zephir_clusters_lookup_by_sysids(sysid_list)
+    print(results)
+
+if __name__ == '__main__':
+    main()

--- a/prepare_zephir_records/test_cid_inquiry_by_ocns_main.py
+++ b/prepare_zephir_records/test_cid_inquiry_by_ocns_main.py
@@ -1,0 +1,51 @@
+# no argument
+def test_main_param_err_0(capsys, setup_leveldb, setup_sqlite):
+    with pytest.raises(SystemExit) as pytest_e:
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# one argument
+def test_main_param_err_1(capsys, setup_leveldb, setup_sqlite):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['dev']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# two arguments
+def test_main_param_err_2(capsys, setup_leveldb, setup_sqlite):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['dev', '1']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# OCN: 300 (not in test db) 
+def test_main_not_in_test_db(capsys, setup_leveldb, setup_sqlite):
+    with pytest.raises(SystemExit) as pytest_e:
+        # env will be override by environment varaiable
+        sys.argv = ['', 'test', '300']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_ocns": [300], "matched_oclc_clusters": [[300, 39867290, 39867383]], "num_of_matched_oclc_clusters": 1, "inquiry_ocns_zephir": [300, 39867290, 39867383], "cid_ocn_list": [], "cid_ocn_clusters": {}, "num_of_matched_zephir_clusters": 0, "min_cid": null}'
+
+    assert  expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+# OCNs: 217211158, 8727632 (test case 1&2 c)
+def test_main_in_test_db_2_clusters(capsys, setup_leveldb, setup_sqlite):
+    with pytest.raises(SystemExit) as pytest_e:
+        # env will be override by environment varaiable
+        sys.argv = ['', 'test', '217211158,8727632']
+        main()
+    out, err = capsys.readouterr()
+
+    expected = '{"inquiry_ocns": [217211158, 8727632], "matched_oclc_clusters": [[8727632, 24253253]], "num_of_matched_oclc_clusters": 1, "inquiry_ocns_zephir": [8727632, 24253253, 217211158], "cid_ocn_list": [{"cid": "000000280", "ocn": "217211158"}, {"cid": "000000280", "ocn": "25909"}, {"cid": "002492721", "ocn": "8727632"}], "cid_ocn_clusters": {"000000280": ["217211158", "25909"], "002492721": ["8727632"]}, "num_of_matched_zephir_clusters": 2, "min_cid": "000000280"}'
+
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+

--- a/prepare_zephir_records/test_local_cid_minter.py
+++ b/prepare_zephir_records/test_local_cid_minter.py
@@ -1,0 +1,91 @@
+# no argument
+def test_main_param_err_0(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# one argument
+def test_main_param_err_1(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+def test_main_param_err_2(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'dev']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+def test_main_read_by_ocns(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'ocn', '8727632,32882115']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_ocns": ["8727632", "32882115"], "matched_cids": [{"cid": "011323405"}, {"cid": "002492721"}], "min_cid": "002492721", "num_of_cids": 2}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_read_by_ocns_not_exists(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'ocn', '1234567890']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_ocns": ["1234567890"], "matched_cids": [], "min_cid": null, "num_of_cids": 0}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_read_by_sysid(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'sysid', 'pur215476']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_sys_id": "pur215476", "matched_cid": "002492721"}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_read_by_sysid_not_exists(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'sysid', 'sysid123']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_write_ocn(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'ocn', '123456789', '100000000']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_write_sysid(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'sysid', 'XY1234567', '200000000']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+# 3|ocn|32882115|011323405|2020-09-16 00:09:26
+def test_main_write_ocn_dup(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'ocn', '32882115', '011323405']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# 4|sysid|pur864352|011323405|2020-09-16 00:09:26
+def test_main_write_sysid_dup(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'sysid', 'pur864352', '011323405']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+

--- a/prepare_zephir_records/test_local_cid_minter_main.py
+++ b/prepare_zephir_records/test_local_cid_minter_main.py
@@ -1,0 +1,65 @@
+# no argument
+def test_main_param_err_0(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+# one argument
+def test_main_param_err_1(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+def test_main_param_err_2(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'dev']
+        main()
+    out, err = capsys.readouterr()
+    assert "Parameter error" in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 1]
+
+def test_main_read_by_ocns(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'ocn', '8727632,32882115']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_ocns": ["8727632", "32882115"], "matched_cids": [{"cid": "011323405"}, {"cid": "002492721"}], "min_cid": "002492721", "num_of_cids": 2}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_read_by_ocns_not_exists(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'ocn', '1234567890']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_ocns": ["1234567890"], "matched_cids": [], "min_cid": null, "num_of_cids": 0}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_read_by_sysid(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'read', 'sysid', 'pur215476']
+        main()
+    out, err = capsys.readouterr()
+    expected = '{"inquiry_sys_id": "pur215476", "matched_cid": "002492721"}'
+    assert expected in out
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_write_ocn(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'ocn', '123456789', '100000000']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]
+
+def test_main_write_sysid(capsys, create_test_db):
+    with pytest.raises(SystemExit) as pytest_e:
+        sys.argv = ['', 'test', 'write', 'sysid', 'XY1234567', '200000000']
+        main()
+    out, err = capsys.readouterr()
+    assert [pytest_e.type, pytest_e.value.code] == [SystemExit, 0]

--- a/prepare_zephir_records/test_oclc_lookup_main.py
+++ b/prepare_zephir_records/test_oclc_lookup_main.py
@@ -1,0 +1,29 @@
+# TEST cmd line options
+def test_main(setup):
+
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code == 1
+    assert 'Usage' in result.output
+
+    result = runner.invoke(main, ['-t'])
+    #assert result.exit_code == 0 
+    assert 'Running tests ...' in result.output
+
+    result = runner.invoke(main, ['--test'])
+    #assert result.exit_code == 0
+    assert 'Running tests ...' in result.output
+
+    result = runner.invoke(main, ['1'])
+    assert result.output ==  '{(1, 6567842, 9987701, 53095235, 433981287)}\n'
+
+    result = runner.invoke(main, ['2'])
+    assert result.output == '{(2, 9772597, 35597370, 60494959, 813305061, 823937796, 1087342349)}\n'
+
+    result = runner.invoke(main, ['1', '2'])
+    assert result.output == '{(2, 9772597, 35597370, 60494959, 813305061, 823937796, 1087342349), (1, 6567842, 9987701, 53095235, 433981287)}\n'
+
+    # '123' is not in the test db
+    result = runner.invoke(main, ['123'])
+    assert result.output == 'set()\n'
+


### PR DESCRIPTION
@cscollett @RvanB Hi Charlie and Raiden,
Another round of refactoring:
* define cid_minter as a package with __init__.py file added
* removed prepare_zephir_records  from the module path
* removed the main function and associated tests from the Python programs in the cid_minter module
* added run scripts (the removed main functions) so we can run the Python programs in the cid_minter module as Python scripts
* saved the unit tests for the main functions in separate files. These can be used as references when we work on the CLI interface. The files will be removed eventually.

Please take a look and let me know if you have questions.

Thank  you

Jing