### PR TITLE
20509 prepare test env

### DIFF
--- a/prepare_zephir_records/README.md
+++ b/prepare_zephir_records/README.md
@@ -1,2 +1,53 @@
 # Prepare Zephir Records
 The application validates contributor submitted MARC records, converts the records to Zephir MARCXML format and assigns a cluster ID to each record.
+# Setup
+1. Deploy zephir-service.git on the server 
+   - Deploy directory: /apps/htmm/zephir-services
+2. Compile or copy the Zephir database configuration file zephir_db.yml from dev or test server
+   - Filename: /apps/htmm/zephir-services/prepare_zephir_records/config/zephir_db.yml
+Sampe database configuration:
+```
+dev:
+    host: rds-d2d-htmm-dev.cmcguhglinoa.us-west-2.rds.amazonaws.com
+    port: 3306
+    username: htmmrw 
+    password: <password>
+    database: htmm
+    drivername: mysql+mysqlconnector
+```
+3. Verify CID minter configuration
+   - The configuration file: /apps/htmm/zephir-services/prepare_zephir_records/config/cid_minting.yml 
+   - Configuration entries:
+     - logpath
+     - Minter database name
+     - LevelDB primary file path
+     - LevelDB cluster file path
+Sample configuraiton:
+```
+dev:
+  minter_db:
+    database:  /apps/htmm/minterdb/cid_minting_store.sqlite
+    drivername: sqlite
+  primary_db_path: /apps/htmm/leveldb/leveldb_files/primary-lookup 
+  cluster_db_path: /apps/htmm/leveldb/leveldb_files/cluster-lookup
+
+logpath: /apps/htmm/log/cid_minting/cid_minting.log
+```
+4. Create the SQLite cid_minting_store.sqlite database
+   - Find the db creating script zephir-services.git/prepare_zephir_records/cid_minter/database/cid_minting_store.sqlite 
+   - Create the cid_minting_store.sqlite with the defined full path `/apps/htmm/minterdb/cid_minting_store.sqlite`
+```
+sqlite3 /apps/htmm/minterdb/cid_minting_store.sqlite < create_cid_minting_store_table.sql
+```
+5. Vefiry LevelDB files - make sure they exist and up-to-date
+   - /apps/htmm/leveldb/leveldb_files/primary-lookup
+   - /apps/htmm/leveldb/leveldb_files/cluster-lookup
+
+6. Verify the log `/apps/htmm/log/cid_minting/cid_minting.log` exists. If not create a new onw
+
+7. Run tests in the following directories:
+   - zephir-services/prepare_zephir_records
+   - zephir-services/prepare_zephir_records/cid_minter
+```
+pipenv run pytest tests/
+```

--- a/prepare_zephir_records/README.md
+++ b/prepare_zephir_records/README.md
@@ -52,7 +52,7 @@ sqlite3 /apps/htmm/minterdb/cid_minting_store.sqlite < create_cid_minting_store_
 pipenv run pytest tests/
 ```
 # How to run the CID minter
-The the CID assignment script `assign_cid_to_zephir_records.py` assigns CIDs to records in a given Zephir records file.
+The CID assignment script `assign_cid_to_zephir_records.py` assigns CIDs to records in a given Zephir records file.
 
 * Directory:/apps/htmm/zephir-services/prepare_zephir_records
 * Script: assign_cid_to_zephir_records.py

--- a/prepare_zephir_records/README.md
+++ b/prepare_zephir_records/README.md
@@ -5,7 +5,7 @@ The application validates contributor submitted MARC records, converts the recor
    - Deploy directory: /apps/htmm/zephir-services
 2. Compile or copy the Zephir database configuration file zephir_db.yml from dev or test server
    - Filename: /apps/htmm/zephir-services/prepare_zephir_records/config/zephir_db.yml
-Sampe database configuration:
+   - Sample database configuration:
 ```
 dev:
     host: rds-d2d-htmm-dev.cmcguhglinoa.us-west-2.rds.amazonaws.com
@@ -22,7 +22,7 @@ dev:
      - Minter database name
      - LevelDB primary file path
      - LevelDB cluster file path
-Sample configuraiton:
+   - Sample configuraiton:
 ```
 dev:
   minter_db:
@@ -43,11 +43,45 @@ sqlite3 /apps/htmm/minterdb/cid_minting_store.sqlite < create_cid_minting_store_
    - /apps/htmm/leveldb/leveldb_files/primary-lookup
    - /apps/htmm/leveldb/leveldb_files/cluster-lookup
 
-6. Verify the log `/apps/htmm/log/cid_minting/cid_minting.log` exists. If not create a new onw
+6. Verify the log `/apps/htmm/log/cid_minting/cid_minting.log` exists. If not create a new one.
 
 7. Run tests in the following directories:
    - zephir-services/prepare_zephir_records
    - zephir-services/prepare_zephir_records/cid_minter
 ```
 pipenv run pytest tests/
+```
+# How to run the CID minter
+The the CID assignment script `assign_cid_to_zephir_records.py` assigns CIDs to records in a given Zephir records file.
+
+* Directory:/apps/htmm/zephir-services/prepare_zephir_records
+* Script: assign_cid_to_zephir_records.py
+
+### To get help:
+```
+pipenv run python  assign_cid_to_zephir_records.py -h
+usage: assign_cid_to_zephir_records.py [-h] [--console] --env
+                                       [{test,dev,stg,prd}] --source_dir
+                                       [SOURCE_DIR] --target_dir [TARGET_DIR]
+                                       --infile [INPUT_FILENAME]
+                                       [--outfile [OUTPUT_FILENAME]]
+
+Assign CID to Zephir records.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --console, -c
+  --env [{test,dev,stg,prd}], -e [{test,dev,stg,prd}]
+  --source_dir [SOURCE_DIR], -s [SOURCE_DIR]
+  --target_dir [TARGET_DIR], -t [TARGET_DIR]
+  --infile [INPUT_FILENAME], -i [INPUT_FILENAME]
+  --outfile [OUTPUT_FILENAME], -o [OUTPUT_FILENAME]
+```
+
+### To assign CIDs to Zephir recors in a file
+Run the `assign_cid_to_zephir_records.py` script with in the `/apps/htmm/zephir-services/prepare_zephir_records` directory:
+```
+cd /apps/htmm/zephir-services/prepare_zephir_records
+
+pipenv run python assign_cid_to_zephir_records.py -e dev -s soruce_file_dir -i input_filename -t target_file_dir -o output_filename(optional)
 ```

--- a/prepare_zephir_records/assign_cid_to_zephir_records.py
+++ b/prepare_zephir_records/assign_cid_to_zephir_records.py
@@ -243,7 +243,8 @@ def main():
     logging.info("Env: {}".format(env))
 
     if output_filename is None:
-        output_filename = f"{input_filename}.cid"
+        output_filename = input_filename
+
     err_filename = f"{input_filename}.err"
     input_file = os.path.join(source_dir, input_filename)
     output_file = os.path.join(target_dir, output_filename)
@@ -251,12 +252,18 @@ def main():
     output_file_tmp = f"/tmp/{output_filename}.tmp"
     err_file_tmp = f"/tmp/{err_filename}.tmp"
 
+    if input_file == output_file:
+        err_msg = f"Filename error: Input and output files share the same path and name. ({input_file})"
+        logging.error(err_msg)
+        print("Exiting ...")
+        print(err_msg)
+        exit(1)
 
-    print("Input file: ", input_file)
-    print("Output file: ", output_file)
-    print("Error file: ", err_file)
-    print("tmp  out: ",  output_file_tmp)
-    print("tmp error: ", err_file_tmp)
+    print("For Testing: Input file: ", input_file)
+    print("For Testing: Output file: ", output_file)
+    print("For Testing: Error file: ", err_file)
+    print("For Testing: tmp output: ",  output_file_tmp)
+    print("For Testing: tmp error: ", err_file_tmp)
 
     assign_cids(config, input_file, output_file_tmp, err_file_tmp)
 
@@ -268,6 +275,7 @@ def main():
     #        os.remove(file)
 
     logging.info("Finished " + os.path.basename(__file__))
+    print("For Testing: Finished " + os.path.basename(__file__))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
@cscollett Hi Charlie,
Here are the two changes:
1. Add readme with setup and testing instructions
2. Name the output file (with CID minted) the same as the input file (Prep output) but make sure the source and target directories are different to prevent input override output. Keeping the filename the same can reduce impact to downstream Gobble processing. It can also reduce code changes to the File Status Report.

Please review and let me know if you have questions.

Thank you

Jing