### PR TITLE
refactoring

### DIFF
--- a/prepare_zephir_records/README.md
+++ b/prepare_zephir_records/README.md
@@ -34,7 +34,16 @@ logpath: /apps/htmm/log/cid_minting/cid_minting.log
 
 5. Verify the log `/apps/htmm/log/cid_minting/cid_minting.log` exists. If not create a new one.
 
-6. Run tests in the following directories:
+6. Setup Pipenv environment
+In the project directory /apps/htmm/zephir-services/prepare_zephir_records
+* Verify the Pipfile and Pipfile.lock files are present
+* Remove current pipenv environment
+* Setup pipenv enviroment from Pipfile and Pipfile.lock
+```
+pipenv --rm
+pipenv install
+```
+7. Run tests in the following directories:
    - zephir-services/prepare_zephir_records
    - zephir-services/prepare_zephir_records/cid_minter
 ```


### PR DESCRIPTION
@cscollett @RvanB Hi Charlie and Raiden,
I updated readme and refactored the [assign_cid_to_zephir_records.py] script:
* Readme: added instructions on how to setup the Pipenv environment
* Renamed variables and functions
* Renamed the locked .pid file back to the original filename (line 303, 304, 305)
* Moved input and output filename error check (Input and output files share the same path and name) to the process_one_file function

Please review and let me know if you have questions.

Thank you

Jing
