### PR TITLE
define and test ZED events

### DIFF
--- a/prepare_zephir_records/assign_cid_to_zephir_records.py
+++ b/prepare_zephir_records/assign_cid_to_zephir_records.py
@@ -360,7 +360,7 @@ def main():
     pid = os.getpid()
     process_key = str(uuid.uuid4())
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    zed_log = os.path.join(zed_log_path, f"zed_cid_{timestamp}_{pid}")
+    zed_log = os.path.join(zed_log_path, f"zed_cid_{timestamp}_{pid}.log")
 
     config = {
         "zephirdb_conn_str": zephirdb_conn_str,

--- a/prepare_zephir_records/cid_minter/tests/test_cid_minter.py
+++ b/prepare_zephir_records/cid_minter/tests/test_cid_minter.py
@@ -186,7 +186,7 @@ def test_step_1_b_1(caplog, setup_configs):
     """Test case 1b1: Found matched cluster by OCNs in Zephir DB.
        Also verifies workflow and error conditions:
          - found current CID
-         - reported warning OCLC Concordance Table does not contain record OCNs
+         - reported warning OCLC Concordance Table does not contain record OCNs - pr0094
          - found CID by OCNs
          - updated local minter
     """
@@ -235,7 +235,7 @@ def test_step_1_b_1(caplog, setup_configs):
     expected_events_sequence = [
         "Found current CID", 
         "Local minter: No CID found by OCN", 
-        "OCLC Concordance Table does not contain record OCNs", 
+        "ZED code: pr0094 - OCLC Concordance Table does not contain record OCNs [80274381, 25231018]", 
         "Zephir minter: Found matched CID", 
         "Local minter: Inserted a new record",
         "Updated local minter: ocn: 80274381", 
@@ -258,7 +258,7 @@ def test_step_1_b_2(caplog, setup_configs):
        Also verifies workflow and error conditions:
          - No CID/item found in Zephir DB by htid
          - Local minter: No CID found by OCN
-         - report warning when OCNs matched to more than one primary OCLC number 
+         - report warning when OCNs matched to more than one primary OCLC number - pr0096
          - Zephir minter: No CID found by OCNs
          - Minted a new CID 
          - updated Local minter
@@ -308,7 +308,7 @@ def test_step_1_b_2(caplog, setup_configs):
         "No CID/item found in Zephir DB by htid",
         "Local minter: No CID found by OCN",
         "Find CID in Zephir Database by OCNs",
-        "match more than one OCLC Concordance clusters",
+        f"ZED code: pr0096 - Record OCNs {incoming_ocns} match more than one OCLC Concordance clusters",
         "Minted a new minter",
         "Local minter: Inserted a new record",
         "Updated local minter: ocn"
@@ -331,7 +331,7 @@ def test_step_1_b_3(caplog, setup_configs):
     """Test case 1b3: Found matched cluster by OCNs in Zephir DB.
        Also verifies workflow and error conditions:
          - found current CID
-         - matched more than one clusters, choose the lower one
+         - matched more than one clusters, choose the lower one: pr0090 (more than one OCN matches more than one cluster)
          - found CID by OCNs
          - updated local minter
     """
@@ -361,8 +361,9 @@ def test_step_1_b_3(caplog, setup_configs):
     for result in results:
         assert result in expected
 
+    ocns = [80274381, 25231018, 30461866]
     # verify in local minter: OCN not in local minter
-    for ocn in ["80274381", "25231018", "30461866"]:
+    for ocn in ocns:
         record = local_minter._find_record_by_identifier("ocn", ocn)
         assert record is None
 
@@ -373,7 +374,8 @@ def test_step_1_b_3(caplog, setup_configs):
 
     expected_events_sequence = [
         "Zephir minter: Found matched CID",
-        "matches 2 CIDs (['009705704', '011323406']) used 009705704",
+        f"ZED code: pr0090 - Record with OCLCs ({ocns}) matches 2 CIDs (['009705704', '011323406']) used 009705704",
+        f"ZED code: pr0213 - Assigned existing CID: 009705704 - assigned by matching OCLC number(s)",
     ]
     verify_events(caplog.text, expected_events_sequence)
     verify_sequenced_events(caplog.text, expected_events_sequence)
@@ -565,7 +567,7 @@ def test_step_2_b_2(caplog, setup_configs):
     """Test case 2b2: Found more than one matched CID by contribsys IDs in Zephir.
          - Report warning matched more than one CID 
          - Choose the lower CID to use
-         - record changed CID
+         - record changed CID - pr0059
          - local minter was updated
     """
     caplog.set_level(logging.DEBUG)
@@ -611,8 +613,8 @@ def test_step_2_b_2(caplog, setup_configs):
          f"Found current CID: {current_cid} by htid: {htid}",
          "Local minter: No CID found by SYSID",
          "Zephir minter: Found matched CIDs: ['000641789', '009705704'] by contribsys IDs: ['hvd000012735', 'nrlf.b100608668']",
-         "Record with local number matches more than one CID",
-         f"Hathi-id (hvd.hw5jdo) changed CID from: {current_cid} to: {expected_cid}",
+         "ZED code: pr0089 - Record with local number matches more than one CID",
+         f"ZED code: pr0059 - WARNING: Hathi-id (hvd.hw5jdo) changed CID from: {current_cid} to: {expected_cid}",
          "Local minter: Inserted a new record",
          "Updated local minter: contribsys id"
     ]
@@ -957,7 +959,7 @@ def test_step_3_b_3(caplog, setup_configs):
     expected_events_sequence = [
         f"Zephir minter: Found matched CIDs: ['{expected_cid}'] by previous contribsys IDs: ['{previous_sysid}']",
         f"Zephir cluster contains records from different contrib systems. Skip this CID ({expected_cid}) assignment",
-        f"Minted a new minter: {cid} - from current minter",
+        f"ZED code: pr0212 - Minted a new minter: {cid} - from current minter",
         "Local minter: Inserted a new record",
         f"Updated local minter: contribsys id: {sysid}",
         f"Updated local minter: previous contribsys id: {previous_sysid}"

--- a/prepare_zephir_records/cid_minter/tests/test_zed_for_cid.py
+++ b/prepare_zephir_records/cid_minter/tests/test_zed_for_cid.py
@@ -1,6 +1,90 @@
-# add test cases
+import os
+import sys
+    
+import pytest
+import json
 
-def test_zed_for_cid():
-    pass
+from cid_minter.zed_for_cid import CidZedEvent
 
+@pytest.fixture
+def setup_zed_msg_table(data_dir, tmpdir, scope="session"):
+    msg_table = os.path.join(data_dir, "columns_prep.csv")
+    zed_log = os.path.join(data_dir, "cid_zed.log")
+
+    return {
+        "msg_table": msg_table,
+        "zed_log": zed_log
+    }
+
+def test_zed_for_cid(caplog, setup_zed_msg_table):
+    msg_table = setup_zed_msg_table["msg_table"]
+    zed_log = setup_zed_msg_table["zed_log"]
+
+    zed_event = CidZedEvent(msg_table, zed_log)
+
+    test_list = []
+    test_item = {
+        "msg_code": "pr0212", # assign new CID
+        "event_data": {
+            "process_key": "92b1be8b-5fa0-44e5-9796-0a2ab3a4d5f0",
+            "msg_detail": "test msg details pr0212",
+            "report": {"CID": "123456789", "RecordID": "100001", "Rd_seq_no": "1", "config_name": "test_config"},
+            "subject": "test subject pr0212",
+            "object": "test object pr0212",
+        },
+        "expected_event": {
+            "status": {"type": "INFO", "zed_code": "200", "msg_code": "pr0212", "msg": "Assigned new CID", "details": "test msg details pr0212"}, 
+            "action": "MintCID", 
+            "type": "Preprun", 
+            "subject": "test subject pr0212", 
+            "object": "test object pr0212", 
+            "topic": "Raw", 
+            "process": "92b1be8b-5fa0-44e5-9796-0a2ab3a4d5f0", 
+            "report": {"CID": "123456789", "RecordID": "100001", "Rd_seq_no": "1", "config_name": "test_config"}
+        }
+    }
+    test_list.append(test_item)
+
+    test_item = {
+        "msg_code": "pr0213", # Assigned existing CID
+        "event_data": {
+            #"process_key": "92b1be8b-5fa0-44e5-9796-0a2ab3a4d5f0", same as previous event
+            "msg_detail": "test msg details pr0213",
+            "report": {"CID": "1234567890", "RecordID": "100002", "Rd_seq_no": "2", "config_name": "test_config"},
+            "subject": "test subject pr0213",
+            "object": "test object pr0213",
+        },
+        "expected_event": {
+            "status": {"type": "INFO", "zed_code": "200", "msg_code": "pr0213", "msg": "Assigned existing CID", "details": "test msg details pr0213"},
+            "action": "MintCID",
+            "type": "Preprun",
+            "subject": "test subject pr0213",
+            "object": "test object pr0213",
+            "topic": "Raw",
+            "process": "92b1be8b-5fa0-44e5-9796-0a2ab3a4d5f0",
+            "report": {"CID": "1234567890", "RecordID": "100002", "Rd_seq_no": "2", "config_name": "test_config"}
+        }
+    }
+    test_list.append(test_item)
+
+    for item in test_list:
+        zed_event.merge_zed_event_data(item.get("event_data"))
+        zed_event.create_zed_event(item.get("msg_code"))
+        created_event = zed_event.zed_event
+        created_event.pop("timestamp", None)
+        created_event.pop("event", None)
+        assert len(created_event) == len(item.get("expected_event"))
+        assert created_event == item.get("expected_event")
+
+    zed_event.close()
+
+    # verify envets were saved in the log file
+    with open(zed_log) as f:
+        i = 0
+        for line in f:
+            created_event = json.loads(line.rstrip())
+            created_event.pop("timestamp", None)
+            created_event.pop("event", None)
+            assert created_event == test_list[i].get("expected_event")
+            i += 1
 

--- a/prepare_zephir_records/cid_minter/zed_for_cid.py
+++ b/prepare_zephir_records/cid_minter/zed_for_cid.py
@@ -14,6 +14,7 @@ class CidZedEvent(object):
         self.zed_msg_table = self._get_zed_msg_table(zed_msg_table_file)
         self.zed_log_fp = open(zed_event_log, "w")
         self.zed_event_data = event_data
+        self.zed_event = None
 
     """ZED msg table: https://github.com/cdlib/htmm-env/blob/master/zed/msg_tables/columns_prep.csv
     """
@@ -54,7 +55,9 @@ class CidZedEvent(object):
             return dict_1 or dict_2
 
     def create_zed_event(self, status_msg_code):
-        """ZED event specification https://docs.google.com/document/d/1vhMV3JGeMhrkNK1n0j05OFYsXgdQD0N_/edit
+        """Create ZED event using event data. Save event as self.zed_event and save it to zed log.
+
+        ZED event specification https://docs.google.com/document/d/1vhMV3JGeMhrkNK1n0j05OFYsXgdQD0N_/edit
             Data model (6/28/2018)
             ## [R]-Required, [O]-Optional
             {
@@ -104,6 +107,7 @@ class CidZedEvent(object):
             "report": self._merge_dict(self.zed_event_data.get("ids"), self.zed_event_data.get("report"))
         }
 
+        self.zed_event = zed_event
         json.dump(zed_event, self.zed_log_fp)
         self.zed_log_fp.write('\n')
 


### PR DESCRIPTION
@cscollett @RvanB Hi Charlie and Raiden,
This is to implement CID minting related ZED events defined in ticket https://cdlib.plan.io/issues/19971 including:
* pr0094 - CID inquiry using OCLC Concordance table failed
* pr0213 Assigned existing CID
* pr0212 Assigned new CID 
* pr0090 Record with OCLC numbers match more than one CID 
* pr0091 Record with one OCLC matches more than one CID 
* pr0089 Record with local number matches more than one CID 
* pr0042 Record containing one previous ILS number matches more than one CID 
* pr0059 Hathi-id changed CID 
* pr0096 Record OCNs matched more than one OCLC Concordance clusters 

Please review and let me know if you have questions.

Thank you

Jing